### PR TITLE
Require common lisp for 'defun*'

### DIFF
--- a/writefreely.el
+++ b/writefreely.el
@@ -37,6 +37,7 @@
 (require 'ox-gfm)
 (require 'json)
 (require 'request)
+(require 'cl)
 
 
 ;;; User-Configurable Variables


### PR DESCRIPTION
The defun* macro's need the `cl` library