### PR TITLE
Single file / multiple posts in single file support

### DIFF
--- a/writefreely.el
+++ b/writefreely.el
@@ -238,7 +238,7 @@ ERROR-THROWN is the request response data."
 
 (defun writefreely-publish-request (title body &optional collection)
   "Send post request to the write.as API endpoint with TITLE and BODY as data.
-Optionally, if COLLECTION is given, publish to it. Returns request response"
+Optionally, if COLLECTION is given, publish to it.  Returns request response"
   (let ((endpoint
          (concat writefreely-instance-api-endpoint
                  (when collection (concat "/collections/" collection))
@@ -373,7 +373,7 @@ This function will attempt to update the contents of a blog post if it finds
        (writefreely-publication-link writefreely-post-id))))
 
 (defvar writefreely-mode-map (make-sparse-keymap)
-  "Keymap for writefreely mode")
+  "Keymap for writefreely mode.")
 
 ;;;###autoload
 (define-minor-mode writefreely-mode


### PR DESCRIPTION
Hi,

This is a work in progress, but I wanted to give you the chance to take a look before it's finished.

It enables a new way of working for writefreely, allowing the user to have multiple posts in a single Org file.

Each post should be its own first-level heading in the file, and each post can be posted, updated, or deleted individually. Per-post metadata is maintained as properties on the headings, instead of as Emacs file-local variables.

Things to probably fix before this is ready to merge:

- I'm not sold on the idea of the customisation variable being called writefreely-multiple-mode (unless this actually made sense to be implemented as a derived minor mode...)

- I haven't updated the docstrings or documentation.

- Some of the functions should be renamed (e.g., writefreely--remove-org-buffer-locals -> writefreely--remove-post-metadata)

Thoughts?